### PR TITLE
Removing the master/slave phrasing

### DIFF
--- a/boto/emr/connection.py
+++ b/boto/emr/connection.py
@@ -204,8 +204,8 @@ class EmrConnection(AWSQueryConnection):
 
     def run_jobflow(self, name, log_uri=None, ec2_keyname=None,
                     availability_zone=None,
-                    master_instance_type='m1.small',
-                    slave_instance_type='m1.small', num_instances=1,
+                    main_instance_type='m1.small',
+                    subordinate_instance_type='m1.small', num_instances=1,
                     action_on_failure='TERMINATE_JOB_FLOW', keep_alive=False,
                     enable_debugging=False,
                     hadoop_version=None,
@@ -231,11 +231,11 @@ class EmrConnection(AWSQueryConnection):
         :type availability_zone: str
         :param availability_zone: EC2 availability zone of the cluster
 
-        :type master_instance_type: str
-        :param master_instance_type: EC2 instance type of the master
+        :type main_instance_type: str
+        :param main_instance_type: EC2 instance type of the main
 
-        :type slave_instance_type: str
-        :param slave_instance_type: EC2 instance type of the slave nodes
+        :type subordinate_instance_type: str
+        :param subordinate_instance_type: EC2 instance type of the subordinate nodes
 
         :type num_instances: int
         :param num_instances: Number of instances in the Hadoop cluster
@@ -266,7 +266,7 @@ class EmrConnection(AWSQueryConnection):
         :param instance_groups: Optional list of instance groups to
             use when creating this job.
             NB: When provided, this argument supersedes num_instances
-            and master/slave_instance_type.
+            and main/subordinate_instance_type.
 
         :type ami_version: str
         :param ami_version: Amazon Machine Image (AMI) version to use
@@ -316,15 +316,15 @@ class EmrConnection(AWSQueryConnection):
         params.update(common_params)
 
         # NB: according to the AWS API's error message, we must
-        # "configure instances either using instance count, master and
-        # slave instance type or instance groups but not both."
+        # "configure instances either using instance count, main and
+        # subordinate instance type or instance groups but not both."
         #
         # Thus we switch here on the truthiness of instance_groups.
         if not instance_groups:
             # Instance args (the common case)
             instance_params = self._build_instance_count_and_type_args(
-                                                        master_instance_type,
-                                                        slave_instance_type,
+                                                        main_instance_type,
+                                                        subordinate_instance_type,
                                                         num_instances)
             params.update(instance_params)
         else:
@@ -487,15 +487,15 @@ class EmrConnection(AWSQueryConnection):
 
         return params
 
-    def _build_instance_count_and_type_args(self, master_instance_type,
-                                            slave_instance_type, num_instances):
+    def _build_instance_count_and_type_args(self, main_instance_type,
+                                            subordinate_instance_type, num_instances):
         """
-        Takes a master instance type (string), a slave instance type
+        Takes a main instance type (string), a subordinate instance type
         (string), and a number of instances. Returns a comparable dict
         for use in making a RunJobFlow request.
         """
-        params = {'Instances.MasterInstanceType': master_instance_type,
-                  'Instances.SlaveInstanceType': slave_instance_type,
+        params = {'Instances.MainInstanceType': main_instance_type,
+                  'Instances.SubordinateInstanceType': subordinate_instance_type,
                   'Instances.InstanceCount': num_instances}
         return params
 

--- a/boto/emr/step.py
+++ b/boto/emr/step.py
@@ -130,7 +130,7 @@ class StreamingStep(Step):
         :param output: The output uri
         :type jar: str
         :param jar: The hadoop streaming jar. This can be either a local
-            path on the master node, or an s3:// URI.
+            path on the main node, or an s3:// URI.
         """
         self.name = name
         self.mapper = mapper

--- a/boto/pyami/bootstrap.py
+++ b/boto/pyami/bootstrap.py
@@ -88,7 +88,7 @@ class Bootstrap(ScriptBase):
             if update.find(':') >= 0:
                 method, version = update.split(':')
             else:
-                version = 'master'
+                version = 'main'
             self.run('git checkout %s' % version, cwd=location)
         else:
             # first remove the symlink needed when running from subversion

--- a/boto/rds/__init__.py
+++ b/boto/rds/__init__.py
@@ -144,8 +144,8 @@ class RDSConnection(AWSQueryConnection):
                           id,
                           allocated_storage,
                           instance_class,
-                          master_username,
-                          master_password,
+                          main_username,
+                          main_password,
                           port=3306,
                           engine='MySQL5.1',
                           db_name=None,
@@ -173,8 +173,8 @@ class RDSConnection(AWSQueryConnection):
         # security_groups should be db_security_groups according to API docs but has been left
         # security_groups for backwards compatibility
         #
-        # master_password should be master_user_password according to API docs but has been left
-        # master_password for backwards compatibility
+        # main_password should be main_user_password according to API docs but has been left
+        # main_password for backwards compatibility
         #
         # instance_class should be db_instance_class according to API docs but has been left
         # instance_class for backwards compatibility
@@ -223,8 +223,8 @@ class RDSConnection(AWSQueryConnection):
                        * sqlserver-ex
                        * sqlserver-web
 
-        :type master_username: str
-        :param master_username: Name of master user for the DBInstance.
+        :type main_username: str
+        :param main_username: Name of main user for the DBInstance.
 
                                 * MySQL must be;
                                   - 1--16 alphanumeric characters
@@ -241,8 +241,8 @@ class RDSConnection(AWSQueryConnection):
                                   - first character must be a letter
                                   - cannot be a reserver SQL Server word
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
 
                                 * MySQL must be 8--41 alphanumeric characters
 
@@ -381,8 +381,8 @@ class RDSConnection(AWSQueryConnection):
         # engine => Engine
         # engine_version => EngineVersion
         # license_model => LicenseModel
-        # master_username => MasterUsername
-        # master_user_password => MasterUserPassword
+        # main_username => MainUsername
+        # main_user_password => MainUserPassword
         # multi_az => MultiAZ
         # option_group_name => OptionGroupName
         # port => Port
@@ -403,8 +403,8 @@ class RDSConnection(AWSQueryConnection):
                   'EngineVersion': engine_version,
                   'Iops': iops,
                   'LicenseModel': license_model,
-                  'MasterUsername': master_username,
-                  'MasterUserPassword': master_password,
+                  'MainUsername': main_username,
+                  'MainUserPassword': main_password,
                   'MultiAZ': str(multi_az).lower() if multi_az else None,
                   'OptionGroupName': option_group_name,
                   'Port': port,
@@ -497,7 +497,7 @@ class RDSConnection(AWSQueryConnection):
 
     def modify_dbinstance(self, id, param_group=None, security_groups=None,
                           preferred_maintenance_window=None,
-                          master_password=None, allocated_storage=None,
+                          main_password=None, allocated_storage=None,
                           instance_class=None,
                           backup_retention_period=None,
                           preferred_backup_window=None,
@@ -520,8 +520,8 @@ class RDSConnection(AWSQueryConnection):
                                              occur.
                                              Default is Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
                                 Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -590,8 +590,8 @@ class RDSConnection(AWSQueryConnection):
             self.build_list_params(params, l, 'DBSecurityGroups.member')
         if preferred_maintenance_window:
             params['PreferredMaintenanceWindow'] = preferred_maintenance_window
-        if master_password:
-            params['MasterUserPassword'] = master_password
+        if main_password:
+            params['MainUserPassword'] = main_password
         if allocated_storage:
             params['AllocatedStorage'] = allocated_storage
         if instance_class:

--- a/boto/rds/dbinstance.py
+++ b/boto/rds/dbinstance.py
@@ -42,7 +42,7 @@ class DBInstance(object):
         in status "available".
     :ivar instance_class: Contains the name of the compute and memory
         capacity class of the DB Instance.
-    :ivar master_username: The username that is set as master username
+    :ivar main_username: The username that is set as main username
         at creation time.
     :ivar parameter_groups: Provides the list of DB Parameter Groups
         applied to this DB Instance.
@@ -80,7 +80,7 @@ class DBInstance(object):
         self.allocated_storage = None
         self.endpoint = None
         self.instance_class = None
-        self.master_username = None
+        self.main_username = None
         self.parameter_groups = []
         self.security_groups = []
         self.read_replica_dbinstance_identifiers = []
@@ -134,8 +134,8 @@ class DBInstance(object):
             self.allocated_storage = int(value)
         elif name == 'DBInstanceClass':
             self.instance_class = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'Port':
             if self._in_endpoint:
                 self._port = int(value)
@@ -249,7 +249,7 @@ class DBInstance(object):
 
     def modify(self, param_group=None, security_groups=None,
                preferred_maintenance_window=None,
-               master_password=None, allocated_storage=None,
+               main_password=None, allocated_storage=None,
                instance_class=None,
                backup_retention_period=None,
                preferred_backup_window=None,
@@ -268,8 +268,8 @@ class DBInstance(object):
             UTC) during which maintenance can occur.  Default is
             Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
             Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -329,7 +329,7 @@ class DBInstance(object):
                                                  param_group,
                                                  security_groups,
                                                  preferred_maintenance_window,
-                                                 master_password,
+                                                 main_password,
                                                  allocated_storage,
                                                  instance_class,
                                                  backup_retention_period,

--- a/boto/rds/dbsnapshot.py
+++ b/boto/rds/dbsnapshot.py
@@ -34,10 +34,10 @@ class DBSnapshot(object):
     :ivar id: Specifies the identifier for the DB Snapshot (DBSnapshotIdentifier)
     :ivar instance_create_time: Specifies the time (UTC) when the snapshot was taken
     :ivar instance_id: Specifies the the DBInstanceIdentifier of the DB Instance this DB Snapshot was created from (DBInstanceIdentifier)
-    :ivar master_username: Provides the master username for the DB Instance
+    :ivar main_username: Provides the main username for the DB Instance
     :ivar port: Specifies the port that the database engine was listening on at the time of the snapshot
     :ivar snapshot_create_time: Provides the time (UTC) when the snapshot was taken
-    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-master-credentials ]
+    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-main-credentials ]
     """
 
     def __init__(self, connection=None, id=None):
@@ -49,7 +49,7 @@ class DBSnapshot(object):
         self.port = None
         self.status = None
         self.availability_zone = None
-        self.master_username = None
+        self.main_username = None
         self.allocated_storage = None
         self.instance_id = None
         self.availability_zone = None
@@ -77,8 +77,8 @@ class DBSnapshot(object):
             self.status = value
         elif name == 'AvailabilityZone':
             self.availability_zone = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'AllocatedStorage':
             self.allocated_storage = int(value)
         elif name == 'SnapshotTime':

--- a/boto/redshift/layer1.py
+++ b/boto/redshift/layer1.py
@@ -250,8 +250,8 @@ class RedshiftConnection(AWSQueryConnection):
             verb='POST',
             path='/', params=params)
 
-    def create_cluster(self, cluster_identifier, node_type, master_username,
-                       master_user_password, db_name=None, cluster_type=None,
+    def create_cluster(self, cluster_identifier, node_type, main_username,
+                       main_user_password, db_name=None, cluster_type=None,
                        cluster_security_groups=None,
                        vpc_security_group_ids=None,
                        cluster_subnet_group_name=None,
@@ -328,9 +328,9 @@ class RedshiftConnection(AWSQueryConnection):
             the Amazon Redshift Management Guide .
         Valid Values: `dw.hs1.xlarge` | `dw.hs1.8xlarge`.
 
-        :type master_username: string
-        :param master_username:
-        The user name associated with the master user account for the cluster
+        :type main_username: string
+        :param main_username:
+        The user name associated with the main user account for the cluster
             that is being created.
 
         Constraints:
@@ -341,9 +341,9 @@ class RedshiftConnection(AWSQueryConnection):
         + Cannot be a reserved word. A list of reserved words can be found in
               `Reserved Words`_ in the Amazon Redshift Developer Guide.
 
-        :type master_user_password: string
-        :param master_user_password:
-        The password associated with the master user account for the cluster
+        :type main_user_password: string
+        :param main_user_password:
+        The password associated with the main user account for the cluster
             that is being created.
 
         Constraints:
@@ -489,8 +489,8 @@ class RedshiftConnection(AWSQueryConnection):
         params = {
             'ClusterIdentifier': cluster_identifier,
             'NodeType': node_type,
-            'MasterUsername': master_username,
-            'MasterUserPassword': master_user_password,
+            'MainUsername': main_username,
+            'MainUserPassword': main_user_password,
         }
         if db_name is not None:
             params['DBName'] = db_name
@@ -1549,7 +1549,7 @@ class RedshiftConnection(AWSQueryConnection):
                        node_type=None, number_of_nodes=None,
                        cluster_security_groups=None,
                        vpc_security_group_ids=None,
-                       master_user_password=None,
+                       main_user_password=None,
                        cluster_parameter_group_name=None,
                        automated_snapshot_retention_period=None,
                        preferred_maintenance_window=None,
@@ -1557,7 +1557,7 @@ class RedshiftConnection(AWSQueryConnection):
         """
         Modifies the settings for a cluster. For example, you can add
         another security or parameter group, update the preferred
-        maintenance window, or change the master user password.
+        maintenance window, or change the main user password.
         Resetting a cluster password or modifying the security groups
         associated with a cluster do not need a reboot. However,
         modifying parameter group requires a reboot for parameters to
@@ -1637,15 +1637,15 @@ class RedshiftConnection(AWSQueryConnection):
         :param vpc_security_group_ids: A list of Virtual Private Cloud (VPC)
             security groups to be associated with the cluster.
 
-        :type master_user_password: string
-        :param master_user_password:
-        The new password for the cluster master user. This change is
+        :type main_user_password: string
+        :param main_user_password:
+        The new password for the cluster main user. This change is
             asynchronously applied as soon as possible. Between the time of the
-            request and the completion of the request, the `MasterUserPassword`
+            request and the completion of the request, the `MainUserPassword`
             element exists in the `PendingModifiedValues` element of the
             operation response.
         Operations never return the password, so this operation provides a way
-            to regain access to the master user account for a cluster if the
+            to regain access to the main user account for a cluster if the
             password is lost.
 
 
@@ -1734,8 +1734,8 @@ class RedshiftConnection(AWSQueryConnection):
             self.build_list_params(params,
                                    vpc_security_group_ids,
                                    'VpcSecurityGroupIds.member')
-        if master_user_password is not None:
-            params['MasterUserPassword'] = master_user_password
+        if main_user_password is not None:
+            params['MainUserPassword'] = main_user_password
         if cluster_parameter_group_name is not None:
             params['ClusterParameterGroupName'] = cluster_parameter_group_name
         if automated_snapshot_retention_period is not None:

--- a/mandrill.py
+++ b/mandrill.py
@@ -144,8 +144,8 @@ class Mandrill(object):
         return '<Mandrill %s>' % self.apikey
 
 class Templates(object):
-    def __init__(self, master):
-        self.master = master
+    def __init__(self, main):
+        self.main = main
 
     def add(self, name, from_email=None, from_name=None, subject=None, code=None, text=None, publish=True):
         """Add a new template
@@ -184,7 +184,7 @@ class Templates(object):
            Error: A general Mandrill error has occurred
         """
         _params = {'name': name, 'from_email': from_email, 'from_name': from_name, 'subject': subject, 'code': code, 'text': text, 'publish': publish}
-        return self.master.call('templates/add', _params)
+        return self.main.call('templates/add', _params)
 
     def info(self, name):
         """Get the information for an existing template
@@ -217,7 +217,7 @@ class Templates(object):
            Error: A general Mandrill error has occurred
         """
         _params = {'name': name}
-        return self.master.call('templates/info', _params)
+        return self.main.call('templates/info', _params)
 
     def update(self, name, from_email=None, from_name=None, subject=None, code=None, text=None, publish=True):
         """Update the code for an existing template
@@ -256,7 +256,7 @@ class Templates(object):
            Error: A general Mandrill error has occurred
         """
         _params = {'name': name, 'from_email': from_email, 'from_name': from_name, 'subject': subject, 'code': code, 'text': text, 'publish': publish}
-        return self.master.call('templates/update', _params)
+        return self.main.call('templates/update', _params)
 
     def publish(self, name):
         """Publish the content for the template. Any new messages sent using this template will start using the content that was previously in draft.
@@ -289,7 +289,7 @@ class Templates(object):
            Error: A general Mandrill error has occurred
         """
         _params = {'name': name}
-        return self.master.call('templates/publish', _params)
+        return self.main.call('templates/publish', _params)
 
     def delete(self, name):
         """Delete a template
@@ -322,7 +322,7 @@ class Templates(object):
            Error: A general Mandrill error has occurred
         """
         _params = {'name': name}
-        return self.master.call('templates/delete', _params)
+        return self.main.call('templates/delete', _params)
 
     def list(self, ):
         """Return a list of all the templates available to this user
@@ -353,7 +353,7 @@ class Templates(object):
            Error: A general Mandrill error has occurred
         """
         _params = {}
-        return self.master.call('templates/list', _params)
+        return self.main.call('templates/list', _params)
 
     def time_series(self, name):
         """Return the recent history (hourly stats for the last 30 days) for a template
@@ -382,7 +382,7 @@ class Templates(object):
            Error: A general Mandrill error has occurred
         """
         _params = {'name': name}
-        return self.master.call('templates/time-series', _params)
+        return self.main.call('templates/time-series', _params)
 
     def render(self, template_name, template_content, merge_vars=None):
         """Inject content and optionally merge fields into a template, returning the HTML that results
@@ -410,12 +410,12 @@ class Templates(object):
            Error: A general Mandrill error has occurred
         """
         _params = {'template_name': template_name, 'template_content': template_content, 'merge_vars': merge_vars}
-        return self.master.call('templates/render', _params)
+        return self.main.call('templates/render', _params)
 
 
 class Users(object):
-    def __init__(self, master):
-        self.master = master
+    def __init__(self, main):
+        self.main = main
 
     def info(self, ):
         """Return the information about the API-connected user
@@ -508,7 +508,7 @@ class Users(object):
            Error: A general Mandrill error has occurred
         """
         _params = {}
-        return self.master.call('users/info', _params)
+        return self.main.call('users/info', _params)
 
     def ping(self, ):
         """Validate an API key and respond to a ping
@@ -521,7 +521,7 @@ class Users(object):
            Error: A general Mandrill error has occurred
         """
         _params = {}
-        return self.master.call('users/ping', _params)
+        return self.main.call('users/ping', _params)
 
     def ping2(self, ):
         """Validate an API key and respond to a ping (anal JSON parser version)
@@ -534,7 +534,7 @@ class Users(object):
            Error: A general Mandrill error has occurred
         """
         _params = {}
-        return self.master.call('users/ping2', _params)
+        return self.main.call('users/ping2', _params)
 
     def senders(self, ):
         """Return the senders that have tried to use this account, both verified and unverified
@@ -559,12 +559,12 @@ class Users(object):
            Error: A general Mandrill error has occurred
         """
         _params = {}
-        return self.master.call('users/senders', _params)
+        return self.main.call('users/senders', _params)
 
 
 class Rejects(object):
-    def __init__(self, master):
-        self.master = master
+    def __init__(self, main):
+        self.main = main
 
     def add(self, email):
         """Adds an email to your email rejection blacklist. Addresses that you
@@ -585,7 +585,7 @@ address that has been whitelisted will have no effect.
            Error: A general Mandrill error has occurred
         """
         _params = {'email': email}
-        return self.master.call('rejects/add', _params)
+        return self.main.call('rejects/add', _params)
 
     def list(self, email=None, include_expired=False):
         """Retrieves your email rejection blacklist. You can provide an email
@@ -626,7 +626,7 @@ include_expired to true to include them.
            Error: A general Mandrill error has occurred
         """
         _params = {'email': email, 'include_expired': include_expired}
-        return self.master.call('rejects/list', _params)
+        return self.main.call('rejects/list', _params)
 
     def delete(self, email):
         """Deletes an email rejection. There is no limit to how many rejections
@@ -647,12 +647,12 @@ has an affect on your reputation.
            Error: A general Mandrill error has occurred
         """
         _params = {'email': email}
-        return self.master.call('rejects/delete', _params)
+        return self.main.call('rejects/delete', _params)
 
 
 class Inbound(object):
-    def __init__(self, master):
-        self.master = master
+    def __init__(self, main):
+        self.main = main
 
     def domains(self, ):
         """List the domains that have been configured for inbound delivery
@@ -670,7 +670,7 @@ class Inbound(object):
            Error: A general Mandrill error has occurred
         """
         _params = {}
-        return self.master.call('inbound/domains', _params)
+        return self.main.call('inbound/domains', _params)
 
     def routes(self, domain):
         """List the mailbox routes defined for an inbound domain
@@ -691,7 +691,7 @@ class Inbound(object):
            Error: A general Mandrill error has occurred
         """
         _params = {'domain': domain}
-        return self.master.call('inbound/routes', _params)
+        return self.main.call('inbound/routes', _params)
 
     def send_raw(self, raw_message, to=None, mail_from=None, helo=None, client_address=None):
         """Take a raw MIME document destined for a domain with inbound domains set up, and send it to the inbound hook exactly as if it had been sent over SMTP
@@ -717,12 +717,12 @@ class Inbound(object):
            Error: A general Mandrill error has occurred
         """
         _params = {'raw_message': raw_message, 'to': to, 'mail_from': mail_from, 'helo': helo, 'client_address': client_address}
-        return self.master.call('inbound/send-raw', _params)
+        return self.main.call('inbound/send-raw', _params)
 
 
 class Tags(object):
-    def __init__(self, master):
-        self.master = master
+    def __init__(self, main):
+        self.main = main
 
     def list(self, ):
         """Return all of the user-defined tag information
@@ -746,7 +746,7 @@ class Tags(object):
            Error: A general Mandrill error has occurred
         """
         _params = {}
-        return self.master.call('tags/list', _params)
+        return self.main.call('tags/list', _params)
 
     def delete(self, tag):
         """Deletes a tag permanently. Deleting a tag removes the tag from any messages
@@ -774,7 +774,7 @@ undo this operation, so use it carefully.
            Error: A general Mandrill error has occurred
         """
         _params = {'tag': tag}
-        return self.master.call('tags/delete', _params)
+        return self.main.call('tags/delete', _params)
 
     def info(self, tag):
         """Return more detailed information about a single tag, including aggregates of recent stats
@@ -862,7 +862,7 @@ undo this operation, so use it carefully.
            Error: A general Mandrill error has occurred
         """
         _params = {'tag': tag}
-        return self.master.call('tags/info', _params)
+        return self.main.call('tags/info', _params)
 
     def time_series(self, tag):
         """Return the recent history (hourly stats for the last 30 days) for a tag
@@ -892,7 +892,7 @@ undo this operation, so use it carefully.
            Error: A general Mandrill error has occurred
         """
         _params = {'tag': tag}
-        return self.master.call('tags/time-series', _params)
+        return self.main.call('tags/time-series', _params)
 
     def all_time_series(self, ):
         """Return the recent history (hourly stats for the last 30 days) for all tags
@@ -918,12 +918,12 @@ undo this operation, so use it carefully.
            Error: A general Mandrill error has occurred
         """
         _params = {}
-        return self.master.call('tags/all-time-series', _params)
+        return self.main.call('tags/all-time-series', _params)
 
 
 class Messages(object):
-    def __init__(self, master):
-        self.master = master
+    def __init__(self, main):
+        self.main = main
 
     def send(self, message, async=False):
         """Send a new transactional message through Mandrill
@@ -1012,7 +1012,7 @@ class Messages(object):
            Error: A general Mandrill error has occurred
         """
         _params = {'message': message, 'async': async}
-        return self.master.call('messages/send', _params)
+        return self.main.call('messages/send', _params)
 
     def send_template(self, template_name, template_content, message, async=False):
         """Send a new transactional message through Mandrill using a template
@@ -1108,7 +1108,7 @@ class Messages(object):
            Error: A general Mandrill error has occurred
         """
         _params = {'template_name': template_name, 'template_content': template_content, 'message': message, 'async': async}
-        return self.master.call('messages/send-template', _params)
+        return self.main.call('messages/send-template', _params)
 
     def search(self, query='*', date_from=None, date_to=None, tags=None, senders=None, limit=100):
         """Search the content of recently sent messages and optionally narrow by date range, tags and senders
@@ -1143,7 +1143,7 @@ class Messages(object):
            Error: A general Mandrill error has occurred
         """
         _params = {'query': query, 'date_from': date_from, 'date_to': date_to, 'tags': tags, 'senders': senders, 'limit': limit}
-        return self.master.call('messages/search', _params)
+        return self.main.call('messages/search', _params)
 
     def parse(self, raw_message):
         """Parse the full MIME document for an email message, returning the content of the message broken into its constituent pieces
@@ -1186,7 +1186,7 @@ class Messages(object):
            Error: A general Mandrill error has occurred
         """
         _params = {'raw_message': raw_message}
-        return self.master.call('messages/parse', _params)
+        return self.main.call('messages/parse', _params)
 
     def send_raw(self, raw_message, from_email=None, from_name=None, to=None, async=False):
         """Take a raw MIME document for a message, and send it exactly as if it were sent over the SMTP protocol
@@ -1212,12 +1212,12 @@ class Messages(object):
            Error: A general Mandrill error has occurred
         """
         _params = {'raw_message': raw_message, 'from_email': from_email, 'from_name': from_name, 'to': to, 'async': async}
-        return self.master.call('messages/send-raw', _params)
+        return self.main.call('messages/send-raw', _params)
 
 
 class Whitelists(object):
-    def __init__(self, master):
-        self.master = master
+    def __init__(self, main):
+        self.main = main
 
     def add(self, email):
         """Adds an email to your email rejection whitelist. If the address is
@@ -1237,7 +1237,7 @@ automatically.
            Error: A general Mandrill error has occurred
         """
         _params = {'email': email}
-        return self.master.call('whitelists/add', _params)
+        return self.main.call('whitelists/add', _params)
 
     def list(self, email=None):
         """Retrieves your email rejection whitelist. You can provide an email
@@ -1259,7 +1259,7 @@ address or search prefix to limit the results. Returns up to 1000 results.
            Error: A general Mandrill error has occurred
         """
         _params = {'email': email}
-        return self.master.call('whitelists/list', _params)
+        return self.main.call('whitelists/list', _params)
 
     def delete(self, email):
         """Removes an email address from the whitelist.
@@ -1277,17 +1277,17 @@ address or search prefix to limit the results. Returns up to 1000 results.
            Error: A general Mandrill error has occurred
         """
         _params = {'email': email}
-        return self.master.call('whitelists/delete', _params)
+        return self.main.call('whitelists/delete', _params)
 
 
 class Internal(object):
-    def __init__(self, master):
-        self.master = master
+    def __init__(self, main):
+        self.main = main
 
 
 class Urls(object):
-    def __init__(self, master):
-        self.master = master
+    def __init__(self, main):
+        self.main = main
 
     def list(self, ):
         """Get the 100 most clicked URLs
@@ -1306,7 +1306,7 @@ class Urls(object):
            Error: A general Mandrill error has occurred
         """
         _params = {}
-        return self.master.call('urls/list', _params)
+        return self.main.call('urls/list', _params)
 
     def search(self, q):
         """Return the 100 most clicked URLs that match the search query given
@@ -1328,7 +1328,7 @@ class Urls(object):
            Error: A general Mandrill error has occurred
         """
         _params = {'q': q}
-        return self.master.call('urls/search', _params)
+        return self.main.call('urls/search', _params)
 
     def time_series(self, url):
         """Return the recent history (hourly stats for the last 30 days) for a url
@@ -1351,12 +1351,12 @@ class Urls(object):
            Error: A general Mandrill error has occurred
         """
         _params = {'url': url}
-        return self.master.call('urls/time-series', _params)
+        return self.main.call('urls/time-series', _params)
 
 
 class Webhooks(object):
-    def __init__(self, master):
-        self.master = master
+    def __init__(self, main):
+        self.main = main
 
     def list(self, ):
         """Get the list of all webhooks defined on the account
@@ -1382,7 +1382,7 @@ class Webhooks(object):
            Error: A general Mandrill error has occurred
         """
         _params = {}
-        return self.master.call('webhooks/list', _params)
+        return self.main.call('webhooks/list', _params)
 
     def add(self, url, description=None, events=[]):
         """Add a new webhook
@@ -1412,7 +1412,7 @@ class Webhooks(object):
            Error: A general Mandrill error has occurred
         """
         _params = {'url': url, 'description': description, 'events': events}
-        return self.master.call('webhooks/add', _params)
+        return self.main.call('webhooks/add', _params)
 
     def info(self, id):
         """Given the ID of an existing webhook, return the data about it
@@ -1440,7 +1440,7 @@ class Webhooks(object):
            Error: A general Mandrill error has occurred
         """
         _params = {'id': id}
-        return self.master.call('webhooks/info', _params)
+        return self.main.call('webhooks/info', _params)
 
     def update(self, id, url, description=None, events=[]):
         """Update an existing webhook
@@ -1472,7 +1472,7 @@ class Webhooks(object):
            Error: A general Mandrill error has occurred
         """
         _params = {'id': id, 'url': url, 'description': description, 'events': events}
-        return self.master.call('webhooks/update', _params)
+        return self.main.call('webhooks/update', _params)
 
     def delete(self, id):
         """Delete an existing webhook
@@ -1500,12 +1500,12 @@ class Webhooks(object):
            Error: A general Mandrill error has occurred
         """
         _params = {'id': id}
-        return self.master.call('webhooks/delete', _params)
+        return self.main.call('webhooks/delete', _params)
 
 
 class Senders(object):
-    def __init__(self, master):
-        self.master = master
+    def __init__(self, main):
+        self.main = main
 
     def list(self, ):
         """Return the senders that have tried to use this account.
@@ -1530,7 +1530,7 @@ class Senders(object):
            Error: A general Mandrill error has occurred
         """
         _params = {}
-        return self.master.call('senders/list', _params)
+        return self.main.call('senders/list', _params)
 
     def domains(self, ):
         """Returns the sender domains that have been added to this account.
@@ -1547,7 +1547,7 @@ class Senders(object):
            Error: A general Mandrill error has occurred
         """
         _params = {}
-        return self.master.call('senders/domains', _params)
+        return self.main.call('senders/domains', _params)
 
     def info(self, address):
         """Return more detailed information about a single sender, including aggregates of recent stats
@@ -1636,7 +1636,7 @@ class Senders(object):
            Error: A general Mandrill error has occurred
         """
         _params = {'address': address}
-        return self.master.call('senders/info', _params)
+        return self.main.call('senders/info', _params)
 
     def time_series(self, address):
         """Return the recent history (hourly stats for the last 30 days) for a sender
@@ -1665,7 +1665,7 @@ class Senders(object):
            Error: A general Mandrill error has occurred
         """
         _params = {'address': address}
-        return self.master.call('senders/time-series', _params)
+        return self.main.call('senders/time-series', _params)
 
 
 


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.